### PR TITLE
Full Parallel Processing!!!

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -168,7 +168,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -218,7 +218,7 @@ jobs:
     if: ${{ always() && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -282,7 +282,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' }}
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-latest"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,11 +276,14 @@ name = "code-to-pdf"
 version = "0.1.8"
 dependencies = [
  "argh",
+ "fast-glob",
  "font-kit",
  "fontdue",
  "ignore",
  "printpdf",
+ "rayon",
  "syntect",
+ "thread_local",
  "two-face",
 ]
 
@@ -492,6 +495,15 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fast-glob"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ea3f6bbcf4dbe2076b372186fc7aeecd5f6f84754582e56ee7db262b15a6f0"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "fdeflate"
@@ -1179,6 +1191,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,6 +1545,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,19 +17,22 @@ required-features = ["font-loading"]
 
 [dependencies]
 argh = "0.1.13"
+fast-glob = "0.4.5"
 font-kit = { version = "0.14.2", optional = true }
 fontdue = "0.9.3"
 ignore = "0.4.23"
 # printpdf = { git = "https://github.com/fschutt/printpdf", default-features = false}
 # printpdf = { path = "../printpdf", default-features = false }
-printpdf = { version = "0.8.2", default-features = false, features = [
+printpdf = { version="0.8.2", default-features = false, features = [
 	"jpeg",
 	"png",
 	"ico",
 	"bmp",
 	"webp",
 ] }
+rayon = "1.10.0"
 syntect = "5.2.0"
+thread_local = "1.1.8"
 two-face = "0.4.3"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Converts a folder of source code to a fully syntax-highlighted PDF
 
 - Syntax highlights code (uses [syntect](https://github.com/trishume/syntect) for highlighting and [two-face](https://crates.io/crates/two-face) for syntax definitions)
 - Automatically handles line wrapping and page overflowing
-- Fast
+- Fast. Processing runs in parallel on multiple cores
 - Error-tolerant
 - Configurable (custom file exclusions, output filename, fonts)
 - Displays images

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -15,8 +15,19 @@ targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
-# Build binary with all features enabled
+# Whether to pass --all-features to cargo build
 all-features = true
 
 [dist.dependencies.apt]
 libfontconfig1-dev = "*"
+
+
+[dist.github-custom-runners]
+global = "ubuntu-latest"
+x86_64-unknown-linux-gnu = "ubunt-latest"
+# aarch64-unknown-linux-gnu = "ubuntu-latest"
+# aarch64-apple-darwin = "ubuntu-latest"
+# aarch64-pc-windows-msvc = "ubuntu-latest"
+# x86_64-apple-darwin = "ubuntu-latest"
+# x86_64-unknown-linux-musl = "ubuntu-latest"
+# x86_64-pc-windows-msvc = "ubuntu-latest"

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -159,7 +159,7 @@ fn main() {
     for local in local_c2pdf.iter() {
         processed_file_count += local.lock().unwrap().processed_file_count();
     }
-	
+
     doc_subset.lock().unwrap().to_document(&mut doc);
     let num_pages = doc.pages.len();
     // let before_write = Instant::now();

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -114,43 +114,7 @@ fn main() {
             .reverse()
         })
         .build();
-    // let doc = Arc::new(Mutex::new(doc));
-    // let mut c2pdf = CodeToPdf::new(
-    //     doc.clone(),
-    //     font_id.clone(),
-    //     page_dimensions,
-    //     TextWrapper::new(font_bytes, args.font_size),
-    //     args.page_text,
-    // );
-    // let highlighter_config = HighlighterConfig::new(
-    //     ss.clone(),
-    //     ts.get(two_face::theme::EmbeddedThemeName::InspiredGithub)
-    //         .clone(),
-    // );
     let start = Instant::now();
-    // c2pdf.process_files(walker, highlighter_config);
-    // for result in walker {
-    // 	dbg!(result.unwrap().path());
-    // }
-    // let tl = ThreadLocal::new();
-    // walker.par_bridge().for_each(|result| {
-    //     let inst = Arc::new(Mutex::new(CodeToPdf::new(
-    //         doc.clone(),
-    //         font_id.clone(),
-    //         page_dimensions,
-    //         TextWrapper::new(font_bytes, args.font_size),
-    //         args.page_text,
-    //     )));
-    //     // let x = tl.get_or(|| {
-    //     //     RefCell::new(CodeToPdf::new(
-    //     //         doc.clone(),
-    //     //         font_id.clone(),
-    //     //         page_dimensions,
-    //     //         TextWrapper::new(font_bytes, args.font_size),
-    //     //         args.page_text,
-    //     //     ))
-    //     // });
-    // });
     let local_c2pdf = ThreadLocal::<Arc<Mutex<CodeToPdf>>>::new();
     let local_highlighter_config = ThreadLocal::<Arc<Mutex<HighlighterConfig>>>::new();
 
@@ -177,12 +141,11 @@ fn main() {
         match result {
             Ok(entry) => {
                 if entry.file_type().is_some_and(|f| f.is_file()) {
-                    if let Err(err) =
-                        c2pdf_mutex
-                            .lock()
-                            .unwrap()
-                            .process_file(entry.path(), &highlight_config_mutex.lock().unwrap(), i)
-                    {
+                    if let Err(err) = c2pdf_mutex.lock().unwrap().process_file(
+                        entry.path(),
+                        &highlight_config_mutex.lock().unwrap(),
+                        i,
+                    ) {
                         println!("ERROR: {}", err);
                     }
                 }
@@ -191,22 +154,12 @@ fn main() {
                 println!("ERROR: {}", err);
             }
         }
-
-        // dbg!(current_thread_index());
-        // let mut c2pdf = CodeToPdf::new(
-        //     doc.clone(),
-        //     font_id.clone(),
-        //     page_dimensions.clone(),
-        //     TextWrapper::new(font_bytes, args.font_size),
-        //     args.page_text.clone(),
-        // );
     });
     let mut processed_file_count = 0;
     for local in local_c2pdf.iter() {
         processed_file_count += local.lock().unwrap().processed_file_count();
     }
-    // let processed_file_count = .processed_file_count();
-    // let doc = doc.lock().unwrap();
+	
     doc_subset.lock().unwrap().to_document(&mut doc);
     let num_pages = doc.pages.len();
     // let before_write = Instant::now();

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -157,7 +157,7 @@ fn main() {
 
     walker.enumerate().par_bridge().for_each(|(i, result)| {
         // let mut doc = PdfDocument::new(&args.name);
-        let c2pdf_and_exclusions = tl.get_or(|| {
+        let c2pdf = tl.get_or(|| {
             Arc::new(Mutex::new(CodeToPdf::new(
                 doc_subset.clone(),
                 font_id.clone(),
@@ -169,8 +169,8 @@ fn main() {
         match result {
             Ok(entry) => {
                 if entry.file_type().is_some_and(|f| f.is_file()) {
-                    let mut c2pdf = c2pdf_and_exclusions.lock().unwrap();
-                    c2pdf.process_file(
+                    let mut c2pdf = c2pdf.lock().unwrap();
+                    if let Err(err) = c2pdf.process_file(
                         entry.path(),
                         &HighlighterConfig::new(
                             ss.clone(),
@@ -178,10 +178,14 @@ fn main() {
                                 .clone(),
                         ),
                         i,
-                    );
+                    ) {
+                        println!("ERROR: {}", err);
+                    }
                 }
             }
-            Err(_) => {}
+            Err(err) => {
+							println!("ERROR: {}", err);
+						}
         }
 
         // dbg!(current_thread_index());

--- a/src/code_to_pdf.rs
+++ b/src/code_to_pdf.rs
@@ -143,6 +143,7 @@ impl CodeToPdf {
                 };
             for (style, text) in regions {
                 let text_width = self.text_wrapper.get_width(text).0;
+
                 let line_width_remaining =
                     self.page_dimensions.max_text_width().into_pt().0 - line_width;
 
@@ -156,7 +157,7 @@ impl CodeToPdf {
                         icc_profile: None,
                     }),
                 });
-								// Split into lines, with the length of the first line being the length remaining on the current line
+                // Split into lines, with the length of the first line being the length remaining on the current line
                 let lines = self.text_wrapper.split_into_lines(text, |i| match i {
                     0 => Pt(line_width_remaining),
                     _ => self.page_dimensions.max_text_width().into_pt(),
@@ -189,8 +190,6 @@ impl CodeToPdf {
                     }
                 }
             }
-
-            // Split text into chunks the maximum width of the view
 
             if !self.increment_line_count(&mut line_count, path) {
                 self.current_page_contents.push(Op::AddLineBreak);

--- a/src/code_to_pdf.rs
+++ b/src/code_to_pdf.rs
@@ -60,6 +60,8 @@ impl DocumentSubset {
         let x_obj_map = mem::take(&mut self.x_object_map);
         doc.resources.xobjects.map = x_obj_map;
         let mut pages = mem::take(&mut self.pages);
+				// Sort into order from the walker
+				// This brings back determinism :)
         pages.sort_by(|a, b| {
             let ia = a.1;
             let ib = b.1;
@@ -121,7 +123,7 @@ impl CodeToPdf {
         );
         _ = self.doc.lock().map(|mut doc| {
             doc.pages.push((page, index));
-            
+            ()
         });
         // self.doc.pages.push(page);
     }
@@ -272,8 +274,8 @@ impl CodeToPdf {
             .doc
             .lock()
             .map(|mut doc| {
-                
-                doc.add_image(&image)
+                let id = doc.add_image(&image);
+                id
             })
             .unwrap();
         let pg_x_dpi = self.page_dimensions.width.into_pt().into_px(300.0).0;

--- a/src/code_to_pdf.rs
+++ b/src/code_to_pdf.rs
@@ -162,8 +162,8 @@ impl CodeToPdf {
                     0 => Pt(line_width_remaining),
                     _ => self.page_dimensions.max_text_width().into_pt(),
                 });
-                // If only a single line, then no new lines are going to be made (as we're processing a region here)
                 match lines.len() {
+                    // If only a single line, then no new lines are going to be made (as we're processing a region here)
                     1 => {
                         self.current_page_contents.push(Op::WriteText {
                             items: vec![TextItem::Text(text.to_owned())],

--- a/src/code_to_pdf.rs
+++ b/src/code_to_pdf.rs
@@ -188,14 +188,14 @@ impl CodeToPdf {
             has_added_text = true;
             // Store the char count for the current line
             let mut line_width = 0.0;
-            let regions: Vec<(Style, &str)> =
+            let regions: &[(Style, &str)] =
                 if line.len() < highlighter_config.max_line_len_to_highlight {
-                    highlighter
+                    &highlighter
                         .highlight_lines
                         .highlight_line(&line, &highlighter_config.syntax_set)
                         .unwrap()
                 } else {
-                    vec![(
+                    &[(
                         Style {
                             foreground: Color::BLACK,
                             background: Color::WHITE,
@@ -227,7 +227,7 @@ impl CodeToPdf {
                     // If only a single line, then no new lines are going to be made (as we're processing a region here)
                     1 => {
                         self.current_page_contents.push(Op::WriteText {
-                            items: vec![TextItem::Text(text.to_owned())],
+                            items: vec![TextItem::Text(text.to_string())],
                             font: self.font_id.clone(),
                         });
                         line_width += text_width;

--- a/src/code_to_pdf.rs
+++ b/src/code_to_pdf.rs
@@ -13,8 +13,8 @@ use std::{
 
 use ignore::Walk;
 use printpdf::{
-    FontId, Op, PdfDocument, PdfPage, Pt, Px, RawImage, TextItem,
-    XObject, XObjectId, XObjectRotation, XObjectTransform, color,
+    FontId, Op, PdfDocument, PdfPage, Pt, Px, RawImage, TextItem, XObject, XObjectId,
+    XObjectRotation, XObjectTransform, color,
 };
 use syntect::{
     easy::HighlightFile,
@@ -23,7 +23,7 @@ use syntect::{
 };
 
 use crate::{dimensions::Dimensions, helpers::init_page, text_manipulation::TextWrapper};
-use rayon::prelude::*;
+
 /// Configuration struct for the highlighter ([`syntect`])
 ///
 /// Contains the desired theme, syntax set, and the maximum line length to highlight
@@ -50,18 +50,20 @@ pub struct DocumentSubset {
     pages: Vec<(PdfPage, usize)>,
 }
 impl DocumentSubset {
+		/// Add an image
     pub fn add_image(&mut self, image: &RawImage) -> XObjectId {
         let id = XObjectId::new();
         self.x_object_map
             .insert(id.clone(), XObject::Image(image.clone()));
         id
     }
+    /// Append everything from the `DocumentSubset` into the actual PdfDocument
     pub fn to_document(&mut self, doc: &mut PdfDocument) {
         let x_obj_map = mem::take(&mut self.x_object_map);
         doc.resources.xobjects.map = x_obj_map;
         let mut pages = mem::take(&mut self.pages);
-				// Sort into order from the walker
-				// This brings back determinism :)
+        // Sort into order from the walker
+        // This brings back determinism :)
         pages.sort_by(|a, b| {
             let ia = a.1;
             let ib = b.1;

--- a/src/code_to_pdf.rs
+++ b/src/code_to_pdf.rs
@@ -133,7 +133,7 @@ impl CodeToPdf {
         );
         _ = self.doc.lock().map(|mut doc| {
             doc.pages.push((page, index));
-            ()
+            
         });
         // self.doc.pages.push(page);
     }
@@ -216,7 +216,7 @@ impl CodeToPdf {
                     self.current_page_contents.push(Op::SetFillColor {
                         col: color::Color::Rgb(to_rgb(text_colour)),
                     });
-										prev_colour = text_colour;
+                    prev_colour = text_colour;
                 }
                 // Split into lines, with the length of the first line being the length remaining on the current line
                 let lines = self.text_wrapper.split_into_lines(text, |i| match i {
@@ -283,8 +283,7 @@ impl CodeToPdf {
             .doc
             .lock()
             .map(|mut doc| {
-                let id = doc.add_image(&image);
-                id
+                doc.add_image(&image)
             })
             .unwrap();
         let pg_x_dpi = self.page_dimensions.width.into_pt().into_px(300.0).0;
@@ -357,11 +356,6 @@ impl CodeToPdf {
             }
         }
     }
-
-    /// Consumes the instance and returns the underlying document
-    // pub fn document(self) -> PdfDocument {
-    //     self.doc
-    // }
 
     /// Returns number of files processed by [`CodeToPdf::process_files`]
     pub fn processed_file_count(&self) -> usize {

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -5,6 +5,7 @@ use printpdf::Mm;
 
 /// Stores the dimensions of the page
 #[allow(missing_docs)]
+#[derive(Debug, Clone)]
 pub struct Dimensions {
     pub width: Mm,
     pub height: Mm,

--- a/src/font_loader.rs
+++ b/src/font_loader.rs
@@ -1,11 +1,7 @@
 //! Functions for loading fonts from the system fonts, a path, or using the bundled `Helvetica` font
 
 #[cfg(feature = "font-loading")]
-use font_kit::family_name::FamilyName;
-#[cfg(feature = "font-loading")]
-use font_kit::properties::Properties;
-#[cfg(feature = "font-loading")]
-use font_kit::source::SystemSource;
+use font_kit::{family_name::FamilyName, properties::Properties, source::SystemSource};
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -16,7 +16,7 @@ pub fn init_page(
     additional_text: Option<&str>,
     wrapper: &mut TextWrapper,
 ) {
-    let mut new_contents = vec![
+    contents.extend_from_slice(&[
         Op::SetLineHeight {
             lh: Pt(font_size * 1.2),
         },
@@ -24,7 +24,7 @@ pub fn init_page(
             size: Pt(font_size),
             font: font_id.clone(),
         },
-    ];
+    ]);
     let mut additional_text_width = 0.0;
     // Write additional text
     if let Some(text) = additional_text {
@@ -34,7 +34,7 @@ pub fn init_page(
                 additional_text_width = line_width
             }
         }
-        new_contents.extend_from_slice(&[
+        contents.extend_from_slice(&[
             Op::SetTextMatrix {
                 matrix: TextMatrix::Translate(Pt(0.0), Pt(0.0)),
             },
@@ -47,14 +47,14 @@ pub fn init_page(
             },
         ]);
         for line in text.lines() {
-            new_contents.push(Op::WriteText {
+            contents.push(Op::WriteText {
                 items: vec![TextItem::Text(line.to_string())],
                 font: font_id.clone(),
             });
-            new_contents.push(Op::AddLineBreak);
+            contents.push(Op::AddLineBreak);
         }
     }
-    new_contents.extend_from_slice(&[
+    contents.extend_from_slice(&[
         Op::SetTextMatrix {
             matrix: TextMatrix::Translate(Pt(0.0), Pt(0.0)),
         },
@@ -75,15 +75,15 @@ pub fn init_page(
             })
         .into_pt()
     }) {
-        new_contents.push(Op::WriteText {
+        contents.push(Op::WriteText {
             items: vec![TextItem::Text(line)],
             font: font_id.clone(),
         });
-        new_contents.push(Op::AddLineBreak);
+        contents.push(Op::AddLineBreak);
     }
 
     // Set cursor to main body
-    new_contents.extend_from_slice(&[
+    contents.extend_from_slice(&[
         // This allows me to reset the text cursor for some reason
         Op::SetTextMatrix {
             matrix: TextMatrix::Translate(Pt(0.0), Pt(0.0)),
@@ -98,5 +98,4 @@ pub fn init_page(
             mode: TextRenderingMode::Fill,
         },
     ]);
-    contents.extend(new_contents);
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -72,7 +72,8 @@ pub fn init_page(
                 Mm::from(Pt(additional_text_width)) + Mm(5.0)
             } else {
                 Mm(0.0)
-            }).into_pt()
+            })
+        .into_pt()
     }) {
         new_contents.push(Op::WriteText {
             items: vec![TextItem::Text(line)],


### PR DESCRIPTION
Paths are traversed, in parallel, using `rayon`.
There is a separate `CodeToPdf` struct per thread stored in a thread local.
Pages are sorted back into the correct order before PDF is written